### PR TITLE
Fix freesolv protocol, parameters and clearance

### DIFF
--- a/freesolv/freesolv.yaml
+++ b/freesolv/freesolv.yaml
@@ -30,7 +30,7 @@ systems:
     solvent1: water
     solvent2: vacuum
     leap:
-      parameters: [oldff/leaprc.ff14SB, leaprc.gaff]
+      parameters: [oldff/leaprc.ff96, leaprc.gaff]
 
 protocols:
   hydration-protocol:

--- a/freesolv/freesolv.yaml
+++ b/freesolv/freesolv.yaml
@@ -3,10 +3,9 @@ options:
   minimize: yes
   verbose: yes
   output_dir: .
-  number_of_iterations: 1000
+  number_of_iterations: 1500
   temperature: 300*kelvin
   pressure: 1*atmosphere
-  softcore_beta: 0.0
 
 molecules:
   molecule:
@@ -21,7 +20,7 @@ solvents:
   water:
     nonbonded_method: PME
     nonbonded_cutoff: 9*angstroms
-    clearance: 9*angstroms
+    clearance: 15*angstroms
   vacuum:
     nonbonded_method: NoCutoff
 
@@ -31,7 +30,7 @@ systems:
     solvent1: water
     solvent2: vacuum
     leap:
-      parameters: [leaprc.ff14SB, leaprc.gaff]
+      parameters: [oldff/leaprc.ff14SB, leaprc.gaff]
 
 protocols:
   hydration-protocol:
@@ -41,8 +40,8 @@ protocols:
         lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80, 0.75, 0.70, 0.65, 0.60, 0.50, 0.40, 0.30, 0.20, 0.10, 0.00]
     solvent2:
       alchemical_path:
-        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
-        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80, 0.75, 0.70, 0.65, 0.60, 0.50, 0.40, 0.30, 0.20, 0.10, 0.00]
+        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00]
+        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00]
 
 experiments:
   system: hydration-system

--- a/t4-lysozyme-l99a/validation.yaml
+++ b/t4-lysozyme-l99a/validation.yaml
@@ -7,7 +7,6 @@ options:
   output_dir: .
   resume_setup: yes
   resume_simulation: yes
-  platform: OpenCL
 
 molecules:
   t4-lysozyme:


### PR DESCRIPTION
Ready for review.

Is there a particular reason why we want to force the platform to be `OpenCL` in the t4lysozyme simulation? Is it ok if I remove it?