### PR TITLE
Update FreeSolv files and first draft automatic validation script

### DIFF
--- a/freesolv/README.md
+++ b/freesolv/README.md
@@ -1,33 +1,37 @@
 # Hydration free energy of the FreeSolv Database (reduced)
 
-## Tutorial
+## Manifest
 
-For a walk through of the files in this example, and running it, please see 
-[our guide on the YANK web page](http://getyank.org/latest/examples/freesolv-imp-exp.html)
+- `freesolv.yaml`: Setup and simulation protocol for YANK. The protocol is chosen to be as close as possible to the
+one described in [1].
+- `freesolv-mini.smiles`: Sub-set of the [FreeSolv database](https://github.com/MobleyLab/FreeSolv) containing SMILES,
+name, experimental and computed hydration free energies of the molecules used for validation.
+- `expected_output.yaml`: Contains the free energies and statistical errors that are expected. It is used by the code
+for automatic analysis.
+- `run-yank.sh`: Bash script to run YANK serially.
+- `run-torque-yank.sh`: Torque script to run YANK with MPI on the cluster.
+- `README.md`: This file.
 
-## Description
+## Choice of the molecules from FreeSolv
 
-This computes hydration free energies frm a subset of the FreeSolv 
-database. Molecules are constructed from their SMILES string (through 
-the OpenEye Toolkit) and both implicit and explicit simulations are run 
-from single YAML file through the `!Combinatorial` argument.
+The 5 molecules in the `freesolv-mini.smiles` set were extracted from the full FreeSolv database. The molecules
+were chosen firstly to span a large dynamic range and secondly to have reasonable agreement between experimental
+and reference computed value.
 
-This example is not meant to introduce anything new, but instead to show 
-that even very complex ideas, like free energy of a database, are not 
-very hard to set up in YANK, once you understand the basics from the 
-other examples.
+## Differences in the protocol
 
-## Usage
+There are few difference from the protocol adopted in [1]:
+- Instead of running an NPT equilibration followed by an NVT production simulation, we run all in NPT and use
+automatic equilibration detection in the analysis.
+- Using tleap instead of packmol, we can't control the exact number of water molecules (1309 in the reference paper).
+We instead add water to create a 13A buffer around the molecule.
+- We use an ewald tolerance of 1e-5 instead of 1e-6.
+- We use a single cutoff for both electrostatics and sterics set to 11A instead of 12A and 10A respectively that
+were employed for the GROMACS simulations.
+- We use hamiltonian replica exchange.
 
-## Running the simulation.
+## References
 
-Set up the simulation to alchemically decouple p-xylene from T4-Lysozyme, putting all the output files in `output/`:
-```bash
-yank script --yaml=yank.yaml
-```
-
-Clean up and delete all simulation files:
-```bash
-yank cleanup --store=output
-```
-
+- [1] Duarte Ramos Matos, G., Kyu, D.Y., Loeffler, H.H., Chodera, J.D., Shirts, M.R. and Mobley, D.L., 2017.
+Approaches for Calculating Solvation Free Energies and Enthalpies Demonstrated with an Update of the FreeSolv Database.
+Journal of Chemical & Engineering Data.

--- a/freesolv/expected_output.yaml
+++ b/freesolv/expected_output.yaml
@@ -1,0 +1,7 @@
+# Each entry is name_of_yank_experiment: [free_energy_in_kcal_per_mol, statistical_error]
+---
+hydrationsystemmolecule0: [3.08, 0.03]
+hydrationsystemmolecule1: [-0.79, 0.03]
+hydrationsystemmolecule2: [-5.54, 0.03]
+hydrationsystemmolecule3: [-8.82, 0.02]
+hydrationsystemmolecule4: [-17.74, 0.03]

--- a/freesolv/freesolv-mini.smiles
+++ b/freesolv/freesolv-mini.smiles
@@ -1,12 +1,8 @@
-mobley_1723043; C1(C(C(C1(F)F)(F)F)(F)F)(F)F; octafluorocyclobutane; 3.43; 0.03; 3.01; 0.04; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; 8263; octafluorocyclobutane; Experimental uncertainty not presently available, so assigned a default value.
-mobley_252413; CCCC(C)(C)C; 2,2-dimethylpentane; 2.88; 0.60; 2.90; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; 11542; 2,2-dimethylpentane; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1662128; CCC=C; but-1-ene; 1.38; 0.60; 2.48; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; 7844; but-1-ene; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1873346; Cc1ccccc1; toluene; -0.90; 0.20; -0.70; 0.10; 10.1039/P29900000291; 10.1021/jp0667442; 1140; toluene; Experimental uncertainty as suggested by 10.1039/P29900000291 -- 0.2 kcal/mol.
-mobley_129464; CCCCOCCCC; 1-butoxybutane; -0.83; 0.60; 0.59; 0.03; 10.1021/ct050097l; 10.1021/ct800409d; 8909; 1-butoxybutane; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1019269; CCCCO; butan-1-ol; -4.72; 0.60; -3.14; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; 263; butan-1-ol; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1520842; Cc1ccncc1; 4-methylpyridine; -4.93; 0.60; -3.41; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; 7963; 4-methylpyridine; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1636752; CO; methanol; -5.10; 0.60; -3.48; 0.01; 10.1021/ct050097l; 10.1021/ct800409d; 887; methanol; Experimental uncertainty not presently available, so assigned a default value.
-mobley_3777264; c1cc(cc(c1)[N+](=O)[O-])N; 3-nitroaniline; -8.84; 0.60; -8.24; 0.03; 10.1021/ct050097l; 10.1021/ct800409d; 7423; 3-nitroaniline; Experimental uncertainty not presently available, so assigned a default value.
-mobley_1963873; CC(=O)NC; N-methylacetamide; -10.00; 0.60; -8.39; 0.03; 10.1021/ct050097l; 10.1021/ct800409d; 6582; N-methylacetamide; Experimental uncertainty not presently available, so assigned a default value.
-mobley_2751110; c1cc(ccc1[N+](=O)[O-])O; 4-nitrophenol; -10.64; 0.60; -8.22; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; 980; 4-nitrophenol; Experimental uncertainty not presently available, so assigned a default value.
-mobley_2727678; c1c(c(=O)[nH]c(=O)[nH]1)I; 5-iodouracil; -18.72; 0.64; -17.14; 0.06; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; 69672; 5-iodouracil; Experimental uncertainty not presently available, so assigned a default value.
+# Extracted from Hydration free energy datbase v0.5, 1/19/17.
+# Semicolon-delimited text file with fields in the following format:
+# compound id (and file prefix); SMILES; iupac name (or alternative if IUPAC is unavailable or not parseable by OEChem); experimental value (kcal/mol); experimental uncertainty (kcal/mol); Mobley group calculated value (GAFF) (kcal/mol); calculated uncertainty (kcal/mol); experimental reference (original or paper this value was taken from); calculated reference; text notes.
+mobley_1723043; C1(C(C(C1(F)F)(F)F)(F)F)(F)F; octafluorocyclobutane; 3.43; 0.03; 3.08; 0.03; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; Experimental uncertainty not presently available, so assigned a default value.
+mobley_1873346; Cc1ccccc1; toluene; -0.90; 0.20; -0.79; 0.03; 10.1039/P29900000291; 10.1021/jp0667442; Experimental uncertainty as suggested by 10.1039/P29900000291 -- 0.2 kcal/mol.
+mobley_4883284; c1ccc(cc1)N; aniline; -5.49; 0.60; -5.54; 0.03; 10.1021/ct050097l; 10.1021/ct800409d; Experimental uncertainty not presently available, so assigned a default value.
+mobley_8048190; CC(=O)N; acetamide; -9.71; 0.60; -8.82; 0.02; 10.1021/ct050097l; 10.1021/ct800409d; Experimental uncertainty not presently available, so assigned a default value.
+mobley_2727678; c1c(c(=O)[nH]c(=O)[nH]1)I; 5-iodouracil; -18.72; 0.64; -17.74; 0.03; 10.1007/s10822-010-9350-8; 10.1007/s10822-010-9343-7; Experimental uncertainty not presently available, so assigned a default value.

--- a/freesolv/freesolv.yaml
+++ b/freesolv/freesolv.yaml
@@ -1,11 +1,15 @@
 ---
 options:
   minimize: yes
-  verbose: yes
+  verbose: no
   output_dir: .
-  number_of_iterations: 1500
-  temperature: 300*kelvin
+  temperature: 298.15*kelvin
   pressure: 1*atmosphere
+  constraints: HBonds
+  timestep: 2*femtoseconds
+  nsteps_per_iteration: 500
+  number_of_iterations: 5000
+  anisotropic_dispersion_cutoff: 16.0*angstroms
 
 molecules:
   molecule:
@@ -19,8 +23,10 @@ molecules:
 solvents:
   water:
     nonbonded_method: PME
-    nonbonded_cutoff: 9*angstroms
-    clearance: 15*angstroms
+    nonbonded_cutoff: 11*angstroms
+    switch_distance: 10*angstroms
+    ewald_error_tolerance: 1e-5
+    clearance: 13*angstroms
   vacuum:
     nonbonded_method: NoCutoff
 
@@ -30,14 +36,14 @@ systems:
     solvent1: water
     solvent2: vacuum
     leap:
-      parameters: [oldff/leaprc.ff96, leaprc.gaff]
+      parameters: [leaprc.water.tip3p, leaprc.gaff]
 
 protocols:
   hydration-protocol:
     solvent1:
       alchemical_path:
-        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
-        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00, 0.95, 0.90, 0.85, 0.80, 0.75, 0.70, 0.65, 0.60, 0.50, 0.40, 0.30, 0.20, 0.10, 0.00]
+        lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+        lambda_sterics:        [1.00, 1.00, 1.00, 1.00, 1.00, 0.95, 0.90, 0.80, 0.70, 0.60, 0.50, 0.40, 0.35, 0.30, 0.25, 0.20, 0.15, 0.10, 0.05, 0.00]
     solvent2:
       alchemical_path:
         lambda_electrostatics: [1.00, 0.75, 0.50, 0.25, 0.00]

--- a/freesolv/freesolv.yaml
+++ b/freesolv/freesolv.yaml
@@ -25,7 +25,7 @@ solvents:
     nonbonded_method: PME
     nonbonded_cutoff: 11*angstroms
     switch_distance: 10*angstroms
-    ewald_error_tolerance: 1e-5
+    ewald_error_tolerance: 1.0e-5
     clearance: 13*angstroms
   vacuum:
     nonbonded_method: NoCutoff
@@ -36,7 +36,7 @@ systems:
     solvent1: water
     solvent2: vacuum
     leap:
-      parameters: [leaprc.water.tip3p, leaprc.gaff]
+      parameters: [leaprc.gaff, leaprc.protein.ff14SB, leaprc.water.tip3p]
 
 protocols:
   hydration-protocol:

--- a/freesolv/freesolv.yaml
+++ b/freesolv/freesolv.yaml
@@ -3,6 +3,7 @@ options:
   minimize: yes
   verbose: no
   output_dir: .
+  checkpoint_interval: 50
   temperature: 298.15*kelvin
   pressure: 1*atmosphere
   constraints: HBonds
@@ -26,7 +27,7 @@ solvents:
     nonbonded_cutoff: 11*angstroms
     switch_distance: 10*angstroms
     ewald_error_tolerance: 1.0e-5
-    clearance: 13*angstroms
+    clearance: 14*angstroms
   vacuum:
     nonbonded_method: NoCutoff
 

--- a/freesolv/run-torque-yank.sh
+++ b/freesolv/run-torque-yank.sh
@@ -3,7 +3,7 @@
 #  Adjust your script as needed for your clusters!
 #
 # walltime : maximum wall clock time (hh:mm:ss)
-#PBS -l walltime=0:10:00
+#PBS -l walltime=72:00:00
 #
 # join stdout and stderr
 #PBS -j oe
@@ -16,13 +16,14 @@
 #
 # nodes: number of nodes
 #   ppn: how many cores per node to use
-#PBS -l nodes=1:ppn=4:gpus=4:shared
+# The protocol has 20 states, so 5x4 GPUs is optimal.
+#PBS -l nodes=5:ppn=4:gpus=4:shared
 #
 # export all my environment variables to the job
 ##PBS -V
 #
 # job name (default = name of script file)
-#PBS -N p-xylene-explicit
+#PBS -N freesolv-yank-validation
 
 if [ -n "$PBS_O_WORKDIR" ]; then 
     cd $PBS_O_WORKDIR
@@ -30,7 +31,5 @@ fi
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."
-build_mpirun_configfile "yank script --yaml=yank.yaml"
-mpiexec.hydra -configfile configfile
-date
-
+build_mpirun_configfile "yank script --yaml=freesolv.yaml" --mpitype general
+mpirun -configfile configfile

--- a/freesolv/run-torque-yank.sh
+++ b/freesolv/run-torque-yank.sh
@@ -31,5 +31,5 @@ fi
 
 # Run the simulation with verbose output:
 echo "Running simulation via MPI..."
-build_mpirun_configfile "yank script --yaml=freesolv.yaml" --mpitype general
+build_mpirun_configfile "yank script --yaml=freesolv.yaml"
 mpirun -configfile configfile

--- a/freesolv/run-yank.sh
+++ b/freesolv/run-yank.sh
@@ -7,7 +7,3 @@
 # Run the simulation
 echo "Running simulation..."
 yank script --yaml=yank.yaml
-
-# Analyze the data
-echo "Analyzing data..."
-yank analyze --store=experiments

--- a/scripts/run_validation.py
+++ b/scripts/run_validation.py
@@ -1,0 +1,123 @@
+#!/usr/local/bin/env python
+
+import os
+import glob
+
+import yaml
+import numpy as np
+
+from yank import mpi
+from yank.analyze import get_analyzer
+from yank.yamlbuild import YamlBuilder
+
+
+# A validation test fails when its Z-score exceeds this threshold.
+MAX_Z_SCORE = 6
+
+
+def run_validation():
+    """Run all validation tests."""
+    for yank_script_filepath in glob.glob(os.path.join('..', '*', '*.yaml')):
+        print('Running {}...'.format(os.path.basename(yank_script_filepath)))
+        yaml_builder = YamlBuilder(yank_script_filepath)
+        yaml_builder.run_experiments()
+
+
+def analyze_directory(experiment_dir):
+    """Return free energy and error of a single experiment.
+
+    Parameters
+    ----------
+    experiment_dir : str
+        The path to the directory storing the nc files.
+
+    Return
+    ------
+    DeltaF : simtk.unit.Quantity
+        Difference in free energy between the end states in kcal/mol.
+    dDeltaF: simtk.unit.Quantity
+        Statistical error of the free energy estimate.
+
+    """
+    analysis_script_filepath = os.path.join(experiment_dir, 'analysis.yaml')
+
+    # Load sign of alchemical phases.
+    with open(analysis_script_filepath, 'r') as f:
+        analysis_script = yaml.load(f)
+
+     # Generate analysis object.
+    analysis = {}
+    for phase_name, sign in analysis_script:
+        phase_path = os.path.join(experiment_dir, phase_name + '.nc')
+        analyzer = get_analyzer(phase_path)
+        analysis[phase_name] = analyzer.analyze_phase()
+        kT = analysis.kT
+
+    # Compute free energy.
+    DeltaF = 0.0
+    dDeltaF = 0.0
+    for phase_name, sign in analysis:
+        DeltaF -= sign * (analysis[phase_name]['DeltaF'] + analysis[phase_name]['DeltaF_standard_state_correction'])
+        dDeltaF += analysis[phase_name]['dDeltaF']**2
+    dDeltaF = np.sqrt(dDeltaF)
+
+    return DeltaF, dDeltaF
+
+
+@mpi.on_single_node(0)
+def print_analysis(experiment_name, expected_free_energy, obtained_free_energy):
+    """Print the results of the analysis.
+
+    Parameters
+    ----------
+    experiment_name : str
+        The name of the experiment to print.
+    expected_free_energy : tuple of float
+        The expected pair (DeltaF, dDeltaF) in kT.
+    obtained_free_energy : tuple of float
+        The pair (DeltaF, dDeltaF) in kT from the calculation.
+
+    """
+    expected_DeltaF = expected_free_energy[0]
+    expected_dDeltaF = expected_free_energy[1]
+    obtained_DeltaF = obtained_free_energy[0]
+
+    # Determine if test has passed.
+    z_score = (obtained_DeltaF - expected_DeltaF) / expected_dDeltaF
+    test_passed = abs(z_score) < MAX_Z_SCORE
+
+    # Print results.
+    print('{}: {}\n'
+          '\texpected: {} * kT\n'
+          '\tobtained: {} * kT\n'
+          '\tZ-score {}:'.format(experiment_name, 'OK' if test_passed else 'FAIL',
+                                 expected_free_energy,
+                                 obtained_free_energy,
+                                 z_score))
+
+
+def run_analysis():
+    """Run analysis on all validation tests."""
+    for expected_output_filepath in glob.glob(os.path.join('..', '*', 'expected_output.yaml')):
+
+        # Load expected results.
+        # expected_output is a dictionary experiment_name: [DeltaF, dDeltaF]
+        with open(expected_output_filepath, 'r') as f:
+            expected_output = yaml.load(f)
+
+        # Find all experiments that we have run so far.
+        testset_dir = os.path.dirname(expected_output_filepath)
+        run_experiments_names = glob.glob(os.path.join(testset_dir, 'experiments', '*'))
+
+        # Distribute analysis of all experiments across nodes.
+        free_energies = mpi.distribute(analyze_directory, run_experiments_names,
+                                       send_results_to='all')
+
+        # Print comparisons.
+        for experiment_id, experiment_name in run_experiments_names:
+            print_analysis(experiment_name, expected_output[experiment_name], free_energies[experiment_id])
+
+
+if __name__ == '__main__':
+    run_validation()
+    run_analysis()


### PR DESCRIPTION
- Updated the FreeSolv YAML script to adopt the unified protocol described in the FreeSolv 0.5 paper.
- Edited the README file (previously copied from `yank-experiments`) to give references and some rationale for molecules/protocol decisions.
- Added a `script/run_validation.py` script with a first draft of the implementation to perform automatic parallel analysis.

**Questions:** When should we consider a validation test "passed"? For now I'm checking that the deviation from the expected free energy is closer than 6 times the FreeSolv statistical error.

@Lnaden could you double check [the analysis code](https://github.com/choderalab/yank-validation/blob/automatic-validation/scripts/run_validation.py#L42-L64)? I'm not sure if there's already a cleaner way to do it.

I'll soon set up the FreeSolv calculations on the cluster with the last YANK version, so that we can catch eventual problems early.